### PR TITLE
Add chatbot crate

### DIFF
--- a/crates/chatbot/Cargo.toml
+++ b/crates/chatbot/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "chatbot"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = { version = "0.8.5", features = ["small_rng"] }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -1,0 +1,30 @@
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::{cell::RefCell, time::Duration};
+
+thread_local! {
+    static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
+}
+
+/// Seeds the thread-local RNG used by [`gen_random_number`].
+pub fn seed_rng(seed: u64) {
+    RNG.with(|rng| *rng.borrow_mut() = SmallRng::seed_from_u64(seed));
+}
+
+/// Generates a random `usize`.
+///
+/// Warning: may take a few seconds!
+pub async fn gen_random_number() -> usize {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    RNG.with(|rng| rng.borrow_mut().gen())
+}
+
+/// Generates a list of possible responses given the current chat.
+///
+/// Warning: may take a few seconds!
+pub async fn query_chat(_messages: &[String]) -> Vec<String> {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    vec![
+        "And how does that make you feel?".to_string(),
+        "Interesting! Go on...".to_string(),
+    ]
+}

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -21,10 +21,11 @@ pub async fn gen_random_number() -> usize {
 /// Generates a list of possible responses given the current chat.
 ///
 /// Warning: may take a few seconds!
-pub async fn query_chat(_messages: &[String]) -> Vec<String> {
+pub async fn query_chat(messages: &[String]) -> Vec<String> {
     tokio::time::sleep(Duration::from_secs(2)).await;
+    let most_recent = messages.last().unwrap();
     vec![
-        "And how does that make you feel?".to_string(),
-        "Interesting! Go on...".to_string(),
+        format!("\"{most_recent}\"? And how does that make you feel?"),
+        format!("\"{most_recent}\"! Interesting! Go on..."),
     ]
 }


### PR DESCRIPTION
This PR adds a new crate, `chatbot`, which provides functions for running an "intelligent" chatbot to respond to the user's queries. Those functions are:
* `chatbot::gen_random_number`: creates a random number from 0 to the maximum `usize`.
* `chatbot::query_chat`: given a set of input messages, queries the model for a vector of generated responses.