### PR TITLE
Add support for retrieval-augmented generation

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -1,5 +1,5 @@
 use rand::{rngs::SmallRng, Rng, SeedableRng};
-use std::{cell::RefCell, time::Duration};
+use std::{cell::RefCell, path::PathBuf, time::Duration};
 
 thread_local! {
     static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
@@ -33,10 +33,17 @@ impl Chatbot {
         }
     }
 
+    pub fn retrieval_documents(&self, _messages: &[String]) -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("data/doc1.txt"),
+            PathBuf::from("data/doc2.txt"),
+        ]
+    }
+
     /// Generates a list of possible responses given the current chat.
     ///
     /// Warning: may take a few seconds!
-    pub async fn query_chat(&mut self, messages: &[String]) -> Vec<String> {
+    pub async fn query_chat(&mut self, messages: &[String], docs: &[String]) -> Vec<String> {
         std::thread::sleep(Duration::from_secs(2));
         let most_recent = messages.last().unwrap();
         let emoji = &self.emojis[self.emoji_counter];
@@ -44,6 +51,8 @@ impl Chatbot {
         vec![
             format!("\"{most_recent}\"? And how does that make you feel? {emoji}",),
             format!("\"{most_recent}\"! Interesting! Go on... {emoji}"),
+            format!("Have you considered: {}", docs.first().unwrap()),
+            format!("I might recommend: {}", docs.last().unwrap()),
         ]
     }
 }

--- a/data/doc1.txt
+++ b/data/doc1.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/data/doc2.txt
+++ b/data/doc2.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet.


### PR DESCRIPTION
Makes two changes to the chatbot API:
1. Add the `retrieval_documents` methods which returns a vector of paths to retrieve from given the current conversation context.
2. Adds the `docs` parameter to `query_chat` which should take the content of the documents specified by `retrieval_documents`.