### PR TITLE
Add Logger data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+Cargo.lock
 log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-Cargo.lock
+log.txt


### PR DESCRIPTION
Defines a `chatbot::Logger` type that has two methods: `Logger::append` for adding a message, and `Logger::save` for intermittently writing to disk. You can construct a logger via `Logger::default()`.